### PR TITLE
Feature/poll for readyness

### DIFF
--- a/docs/browser.md
+++ b/docs/browser.md
@@ -22,7 +22,10 @@ Option | Type | Description
 `verbose` | `Boolean` | Enables extensive logging
 `baseUrl` | `String` | The URL to be used as the base for `go()` calls. This usually is the domain where your target is running
 `jQuery` | `Boolean` | Injects `jQuery` into the browser
-`setupWindow` | `Function` | Add extra helper-methods for your tests here, or wait for the client to be initialized with a `Promise`
+`setupWindow` | `Function` | Add extra helper-methods for your tests here.
+`readyWhen` | `Function` | Whether or not `window` is ready to be tested.
+`readyWhenInterval` | `Integer` | The speed of polling in `ms` (default: `10`)
+`readyWhenTimeout` | `Integer` | The maximum amount of polling in `ms` (default: `2000`)
 
 ## Usage
 The configured browser will be exposed by GreenLight:
@@ -46,6 +49,27 @@ browser
   });
 ```
 
+## readyWhen
+When the client needs more time to be ready, you can use `readyWhen`:
+
+```js
+GreenLight
+  .init()
+  .then(() => {
+    return GreenLight.runBrowser({
+      baseUrl: 'http://localhost:8000',
+      readyWhen: (window) => {
+        return document.body.classList.contains('initialized');
+        // ...or whatever your client does when it's ready, it may also be something like:
+        // return window.isInitialized === true;
+      }
+    });
+  })
+});
+```
+
+The `readyWhen` function will be called every couple of ms (configurable with `readyWhenInterval`) and it will time out when it takes too long (configurable with `readyWhenTimeout`). When you don't configure `readyWhen`, the client is considered ready immediately.
+
 ## Command line overrides
 You can override configuration through the CLI:
 
@@ -54,5 +78,7 @@ Command | Description
 `--browser-verbose` | Enables extensive logging
 `--browser-jQuery` | Injects `jQuery` into the browser
 `--browser-baseUrl` | The URL to be used as the base for `go()` calls
+`--browser-readyWhenInterval` | The speed of polling in `ms`
+`--browser-readyWhenTimeout` | The maximum amount of polling in `ms`
 
 [Read this](./command-line-overrides.md) for more information about command line overrides.

--- a/docs/command-line-overrides.md
+++ b/docs/command-line-overrides.md
@@ -23,6 +23,7 @@ Command | Description
 `--target-cwd` | The current working directory of the command
 `--target-checkUrl` | The URL which will be polled to know it's ready
 `--target-checkInterval` | The speed of polling in `ms`
+`--target-checkTimeout` | The maximum time of polling in `ms`
 `--browser-verbose` | Enables extensive logging
 `--browser-jQuery` | Injects `jQuery` into the browser
 `--browser-baseUrl` | The URL to be used as the base for `go()` calls

--- a/docs/command-line-overrides.md
+++ b/docs/command-line-overrides.md
@@ -23,10 +23,12 @@ Command | Description
 `--target-cwd` | The current working directory of the command
 `--target-checkUrl` | The URL which will be polled to know it's ready
 `--target-checkInterval` | The speed of polling in `ms`
-`--target-checkTimeout` | The maximum time of polling in `ms`
+`--target-checkTimeout` | The maximum amount of polling in `ms`
 `--browser-verbose` | Enables extensive logging
 `--browser-jQuery` | Injects `jQuery` into the browser
 `--browser-baseUrl` | The URL to be used as the base for `go()` calls
+`--browser-readyWhenInterval` | The speed of polling in `ms`
+`--browser-readyWhenTimeout` | The maximum amount of polling in `ms`
 `--tests-verbose` | Enables extensive logging
 `--tests-glob` | Pattern to find your tests
 `--tests-mocha-grep` | The `grep` option for Mocha

--- a/docs/target.md
+++ b/docs/target.md
@@ -25,6 +25,7 @@ Option | Type | Description
 `cwd` | `String` | The current working directory of the command (only if you need it, because you can't do something like `cd app/whatever/path && npm start`)
 `checkUrl` | `String` | The URL which will be polled to know it's ready (usually the homepage or a status-page of some sorts)
 `checkInterval` | `Integer` | The speed of polling in `ms` (default: `1000`)
+`checkTimeout` | `Integer` | The maximum time of polling in `ms` (default: `1000`)
 
 ## Command line overrides
 You can override configuration through the CLI:
@@ -36,5 +37,6 @@ Command | Description
 `--target-cwd` | The current working directory of the command
 `--target-checkUrl` | The URL which will be polled to know it's ready
 `--target-checkInterval` | The speed of polling in `ms`
+`--target-checkTimeout` | The maximum time of polling in `ms`
 
 [Read this](./command-line-overrides.md) for more information about command line overrides.

--- a/docs/target.md
+++ b/docs/target.md
@@ -25,7 +25,7 @@ Option | Type | Description
 `cwd` | `String` | The current working directory of the command (only if you need it, because you can't do something like `cd app/whatever/path && npm start`)
 `checkUrl` | `String` | The URL which will be polled to know it's ready (usually the homepage or a status-page of some sorts)
 `checkInterval` | `Integer` | The speed of polling in `ms` (default: `1000`)
-`checkTimeout` | `Integer` | The maximum time of polling in `ms` (default: `1000`)
+`checkTimeout` | `Integer` | The maximum amount of polling in `ms` (default: `300000` / 5 minutes)
 
 ## Command line overrides
 You can override configuration through the CLI:
@@ -37,6 +37,6 @@ Command | Description
 `--target-cwd` | The current working directory of the command
 `--target-checkUrl` | The URL which will be polled to know it's ready
 `--target-checkInterval` | The speed of polling in `ms`
-`--target-checkTimeout` | The maximum time of polling in `ms`
+`--target-checkTimeout` | The maximum amount of polling in `ms`
 
 [Read this](./command-line-overrides.md) for more information about command line overrides.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "green-light",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": "Jasper Haggenburg",
   "description": "An opinionated (but complete) set of tools for functional testing",
   "license": "ISC",
@@ -47,6 +47,7 @@
     "mocha": "^2.4.5",
     "mocked-api": "^0.6.3",
     "node-fetch": "^1.4.1",
+    "promise-poller": "^1.3.0",
     "terminate": "^1.0.8"
   }
 }

--- a/src/browser.js
+++ b/src/browser.js
@@ -1,7 +1,7 @@
 import jsdom from 'jsdom';
-
 import path from 'path';
 import fs from 'fs';
+import poll from 'promise-poller';
 
 export default class Browser {
   constructor(config) {
@@ -9,7 +9,10 @@ export default class Browser {
       verbose: config.verbose,
       baseUrl: config.baseUrl,
       jQuery: config.jQuery,
-      setupWindow: config.setupWindow || (w => Promise.resolve(w)),
+      setupWindow: config.setupWindow || (w => w),
+      readyWhen: config.readyWhen || (w => true),
+      readyWhenInterval: config.readyWhenInterval || 10,
+      readyWhenTimeout: config.readyWhenTimeout || 2000,
     };
 
     if (!this.config.baseUrl) {
@@ -47,10 +50,10 @@ export default class Browser {
     }
 
     return this._getDOM(url)
-      .then(window => {
-        this.window = window;
-        return this.config.setupWindow(window);
-      })
+      .then(window => this.window = window)
+      .then(() => this._waitForReady(this.window))
+      .then(() => this.config.setupWindow(this.window))
+      .then(() => this.window)
       .catch(err => {
         console.error(`Something went wrong at: ${url}`);
         console.trace(err);
@@ -84,5 +87,14 @@ export default class Browser {
         },
       });
     });
+  }
+
+  _waitForReady(window) {
+    return poll({
+      taskFn: () => this.config.readyWhen(window) ? Promise.resolve() : Promise.reject(),
+      interval: this.config.readyWhenInterval,
+      // timeout: this.config.readyWhenTimeout,
+      retries: this.config.readyWhenTimeout / this.config.readyWhenInterval, // Tmp fix for: https://github.com/joeattardi/promise-poller/issues/4
+    }).catch(err => Promise.reject(new Error('browser timeout')));
   }
 }

--- a/src/target.js
+++ b/src/target.js
@@ -82,6 +82,8 @@ export default class Target {
         taskFn: () => this.check(),
         interval: this.config.checkInterval,
         timeout: this.config.checkTimeout,
+        // timeout: this.config.checkTimeout,
+        retries: this.config.checkTimeout / this.config.checkInterval, // Tmp fix for: https://github.com/joeattardi/promise-poller/issues/4
       }).then(resolve, reject);
     });
   }

--- a/src/utils/config-helper.js
+++ b/src/utils/config-helper.js
@@ -19,6 +19,7 @@ const cli = commandLineArgs([
   { name: 'target-cwd', type: String },
   { name: 'target-checkUrl', type: String },
   { name: 'target-checkInterval', type: Number },
+  { name: 'target-checkTimeout', type: Number },
 
   /*
    * Browser


### PR DESCRIPTION
Fixes #20.
- `Target` now has a `checkTimeout`, which can be configured to let the checking time out
- `Browser` now has a `readyWhen` (with a `readyWhenInterval` and `readyWhenTimeout`) to check if the client is ready
