### PR TITLE
promise-poller update broke waitForReady

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -93,7 +93,8 @@ export default class Browser {
 
   _waitForReady(window) {
     return poll({
-      taskFn: () => this.config.readyWhen(window) ? Promise.resolve() : Promise.reject(),
+      taskFn: () => this.config.readyWhen(window) ? Promise.resolve(true) : Promise.reject(),
+      shouldContinue: (err, ready) => !ready,
       interval: this.config.readyWhenInterval,
       // timeout: this.config.readyWhenTimeout,
       retries: this.config.readyWhenTimeout / this.config.readyWhenInterval, // Tmp fix for: https://github.com/joeattardi/promise-poller/issues/4


### PR DESCRIPTION
A new feature `shouldContinue` was implemented in promise-poller 1.6.0. This change fixes the issue for me.